### PR TITLE
feat(deep-research): v1.4.0 — evidence-basis discipline (four-label facts)

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ agent_skills/
 │   ├── clips-studio/                 ← staged fal.ai short-video generation/animation/camera moves
 │   └── pexels-stock-photos/          ← free real-world stock photo search + download (Pexels API)
 ├── research/                         ← source-grounded research, enrichment, and RAG skills
-│   ├── deep-research/                ← iterative research engine with structured evidence, source quality ranking, refute polarity
+│   ├── deep-research/                ← iterative research engine with structured evidence, source quality ranking, refute polarity, four-label evidence-basis discipline
 │   ├── entity-research/              ← cited entity/person background dossiers + sanctions signals
 │   ├── news-monitoring/              ← recurring news digests with cron delivery + multi-language
 │   ├── notebooklm-mode/              ← NotebookLM-style source vault + grounded answers
@@ -56,7 +56,7 @@ New skills are added as folders under the relevant domain directory.
 | [image-studio](creative/image-studio/) | creative | Staged fal.ai image gen/edit/upscale/cleanup with cost logging + `--dry-run` | pexels-stock-photos |
 | [clips-studio](creative/clips-studio/) | creative | Staged fal.ai short-video: text-to-video, animate still, camera moves | image-studio |
 | [pexels-stock-photos](creative/pexels-stock-photos/) | creative | Free real-world stock photos (Pexels API, 20k/month) with attribution handling | image-studio |
-| [deep-research](research/deep-research/) | research | Iterative research engine: structured evidence, source quality ranking (primary/secondary/tertiary), refute polarity, overview-first reports | fact-checker, source-tracker |
+| [deep-research](research/deep-research/) | research | Iterative research engine: structured evidence, source quality ranking (primary/secondary/tertiary), refute polarity, overview-first reports, four-label evidence-basis discipline ([VERIFIED]/[SOURCED]/[REASONED]/[ESTIMATED]) | fact-checker, source-tracker |
 | [entity-research](research/entity-research/) | research | Cited company/person dossiers: ownership, adverse media, sanctions, litigation | deep-research |
 | [people-enrichment](research/people-enrichment/) | research | PDL person/company lookup → styled `.xlsx` | entity-research |
 | [library-rag](research/library-rag/) | research | Semantic search over personal library (bge-m3 + sqlite-vec) | notebooklm-mode |

--- a/research/deep-research/SKILL.md
+++ b/research/deep-research/SKILL.md
@@ -10,14 +10,14 @@ description: >
   into X in depth", "write a report on X", or any question needing multi-source
   synthesis beyond a single search. For entity vetting/dossiers use entity-research;
   for news digests use news-monitoring; for source-grounded Q&A use notebooklm-mode.
-version: 1.3.0
+version: 1.4.0
 author: moonlight-lupin
 license: MIT
 platforms: [linux, macos, windows]
 metadata:
   hermes:
-    tags: [research, deep-research, report, synthesis, iterative, citations]
-    related_skills: [news-monitoring, entity-research, notebooklm-mode, youtube-topic-research]
+    tags: [research, deep-research, report, synthesis, iterative, citations, evidence-basis, provenance]
+    related_skills: [news-monitoring, entity-research, notebooklm-mode, youtube-topic-research, fact-checker, source-tracker]
 ---
 
 # Deep Research — Iterative Research Engine
@@ -175,6 +175,26 @@ For each quality source, extract **goal-relevant facts**:
 - Prefer specific data, statistics, named sources, dates over vague claims
 - Record the source URL and title with each extracted fact
 - **Classify source quality** for each source: `primary` (official docs, model cards, SEC filings, original papers), `secondary` (tech journalism, analyst reports, reviews), `tertiary` (Wikipedia, aggregators, forum posts). This tier appears in the final source table and signals evidence strength to the reader.
+- **Grade each fact's evidence basis** as you extract (see below) — you can't tag a report you didn't grade while reading
+
+### Evidence basis — the four-label discipline
+
+Tag every **material fact** with the basis on which you're asserting it. A material fact is any substantive claim a reader would act on or challenge: a statistic, date, named entity or relationship, causal claim, or direct quote. This is deep-research's adaptation of pere-toolkit's canonical evidence discipline — the **same four labels**, applied to *facts* rather than financial figures.
+
+| Label | A fact is `[LABEL]` when it is… |
+|---|---|
+| `[VERIFIED]` | corroborated across ≥2 independent, cited, dated sources |
+| `[SOURCED]` | stated by one named / cited source, not independently corroborated |
+| `[REASONED]` | your own analytical judgement or inference — not stated by any source |
+| `[ESTIMATED]` | a calculation or stated assumption (e.g. a figure you derived from source data) |
+
+Rules:
+- **Lead on `[VERIFIED]` / `[SOURCED]`.** Present `[REASONED]` / `[ESTIMATED]` claims as *indicative* ("likely", "suggests", "on these figures") — never as hard fact.
+- **Use these four exact labels** — never an improvised synonym (`[Official]`, `[Expert]`, `[Consensus]` → these are `[SOURCED]`, or `[VERIFIED]` only if independently corroborated).
+- **Don't restate precision you don't have** — a source's "about half" is `~50% [SOURCED]`, not `50.0%`.
+- **Never fabricate to fill a gap** — an unanswerable sub-question is a documented gap, not a `[REASONED]` guess dressed as fact.
+
+**Relationship to source-quality tiers:** the `primary`/`secondary`/`tertiary` tier (above) classifies the *source*; the `[VERIFIED]`/`[SOURCED]`/`[REASONED]`/`[ESTIMATED]` label classifies the *fact*. They are orthogonal: a fact from a single primary source is `[SOURCED]` (strong source, but uncorroborated); the same fact from two independent primary sources becomes `[VERIFIED]`. Use both: tier in the source table, label inline on each claim.
 
 ### 3d — Synthesis
 
@@ -186,7 +206,7 @@ After extracting from all sources in the round, integrate findings into the **cu
 
 ### Sub-question 1: [question]
 Status: [answered / partially answered / unanswered]
-Findings: [synthesized facts with inline citations like (Source: URL, Title)]
+Findings: [synthesized facts, each with an inline citation (Source: URL, "Title") and an evidence-basis tag, e.g. "adoption grew 40% in 2025 (Source: …) [VERIFIED]"]
 
 ### Sub-question 2: [question]
 Status: [...]
@@ -200,6 +220,7 @@ Synthesis rules:
 - **Deduplicate** — if multiple sources say the same thing, cite the best one (or cite both for corroboration)
 - **Resolve contradictions** — if sources disagree, present both with attribution. Do not arbitrate silently.
 - **Inline citations** — every factual claim references its source: `(Source: URL, "Title")`
+- **Evidence basis** — tag each material fact `[VERIFIED]` / `[SOURCED]` / `[REASONED]` / `[ESTIMATED]` (see §3c). A fact becomes `[VERIFIED]` only once ≥2 *independent* sources corroborate it; a single source is `[SOURCED]`. Corroboration during dedup is what promotes `[SOURCED]` → `[VERIFIED]`.
 - **Update gap list** — what sub-questions are still unanswered or thin?
 
 ### 3e — Structured Evidence (recommended for reports with 5+ sources)
@@ -255,6 +276,8 @@ Produce the final report. Minimum 800 words (scale with topic complexity).
 
 **Output order is overview-first**: the reader gets the answer and the at-a-glance comparison *before* the detailed reasoning. Do not bury the comparison table after the per-topic analysis.
 
+Carry each material fact's **evidence-basis tag** inline (§3c), lead on `[VERIFIED]` / `[SOURCED]`, keep `[REASONED]` / `[ESTIMATED]` claims framed as indicative, and paste the **Evidence key** legend below the Sources table so the tags decode.
+
 ### Structure
 
 ```markdown
@@ -291,6 +314,8 @@ Produce the final report. Minimum 800 words (scale with topic complexity).
 | # | Title | URL | Quality | Accessed |
 |---|-------|-----|---------|----------|
 | 1 | [title] | [url] | primary/secondary/tertiary | [date] |
+
+**Evidence key** — `[VERIFIED]` corroborated across ≥2 independent, cited, dated sources · `[SOURCED]` from one named source, not independently corroborated · `[REASONED]` analytical judgement / inference · `[ESTIMATED]` calculation or stated assumption.
 ```
 
 ### Category-specific overview sections
@@ -308,7 +333,7 @@ Produce the final report. Minimum 800 words (scale with topic complexity).
 
 If LLM synthesis fails (timeout, error, garbled output), compile raw findings into a basic report:
 - List all findings grouped by sub-question
-- Include source URLs
+- Include source URLs and keep each finding's evidence-basis tag
 - Add note: "This is a raw findings compilation; synthesis was not completed."
 - Never output "No information could be gathered" if any sources were fetched — always compile what exists.
 
@@ -393,9 +418,12 @@ delegate_task(
 - **No quality filter** — including thin/irrelevant sources dilutes the report. Filter before extraction.
 - **Listing instead of synthesizing** — the report should synthesize findings, not list them. Resolve contradictions, identify themes, draw conclusions.
 - **Missing citations** — every factual claim in the final report must have an inline citation with URL + source title.
+- **Missing evidence-basis tags** — a material fact with a citation but no `[VERIFIED]`/`[SOURCED]`/`[REASONED]`/`[ESTIMATED]` tag is half-graded. Tag it, and include the Evidence key so the tags decode.
+- **Improvised evidence labels** — use only the four canonical tags. A synonym like `[Official]`, `[Confirmed]`, or `[Consensus]` breaks the discipline; map it to one of the four.
+- **Overclaiming basis** — don't tag a single-source fact `[VERIFIED]`, and don't restate precision the source didn't give. When torn between two labels, pick the weaker one.
 - **Synthesis failure produces nothing** — always use the fallback report if synthesis fails. Raw findings > no output.
 - **Ignoring contradictions** — if sources disagree, present both. Don't silently pick one.
-- **Fabricating sources** — never invent URLs, titles, or facts. If a sub-question can't be answered, document it as a gap.
+- **Fabricating sources** — never invent URLs, titles, or facts. If a sub-question can't be answered, document it as a gap — never a `[REASONED]` guess dressed as a sourced fact.
 - **No counter-evidence search** — only searching for supporting evidence produces biased research. Round 2+ must include at least one counter-evidence query. If none found, say so explicitly.
 - **Missing gaps/contradictions sections** — the report must surface what's unknown and where sources disagree. Omitting these sections hides uncertainty from the reader and signals incomplete research.
 - **No source quality classification** — unclassified sources make it impossible to judge evidence strength. Always tag primary/secondary/tertiary in the source table.

--- a/research/deep-research/evals/routing-fixtures.json
+++ b/research/deep-research/evals/routing-fixtures.json
@@ -10,7 +10,7 @@
         "reason": "Open-ended multi-source synthesis into a single cited report. Not a recurring digest, not a dossier on one named entity, not Q&A over user-supplied sources.",
         "not": ["news-monitoring", "entity-research", "notebooklm-mode"]
       },
-      "required_output_fields": ["inline citations", "sources/references list", "research stats"],
+      "required_output_fields": ["inline citations", "evidence-basis tags ([VERIFIED]/[SOURCED]/[REASONED]/[ESTIMATED]) with an evidence key", "sources/references list with quality tiers", "research stats"],
       "forbidden_patterns": ["(?i)as an ai language model", "(?i)i cannot (browse|access) the (web|internet)", "(?i)\\bi made (this|that|these) up\\b"]
     },
     {

--- a/research/deep-research/references/structured-evidence-format.md
+++ b/research/deep-research/references/structured-evidence-format.md
@@ -159,6 +159,38 @@ A deeper test ran the v1.2.0 methodology end-to-end on a 5-dimension research qu
 
 **Cost overhead:** evidence.json was 18.6KB + report 14KB = ~33KB total, vs ~14KB for a single-pass report. ~2.4× overhead for materially higher quality (explicit gaps, forced counter-evidence, source quality awareness, full traceability). Worth it for research informing decisions; skip for quick lookups.
 
+## Third Validation: Source Quality Ranking Stress Test (July 2026)
+
+A third test ran the v1.3.0 methodology (with source quality ranking) on: *"Is RAG obsolete in 2026? Long-context windows vs retrieval-augmented generation for AI agents — when does each approach win?"*
+
+**Results:** 15 claims, 6 sources, 5 refute-polarity claims, 3 writing_context items. 3 research rounds, 7 queries, ~5 minutes.
+
+**Source quality distribution: 4 primary (67%), 2 secondary (33%), 0 tertiary (0%) — healthy.**
+
+This was the first test where the quality distribution check deliberately drove the search strategy. Knowing the check was coming, the search targeted arXiv papers and vendor research blogs first, not tech journalism. Results:
+
+| Metric | Test 1 (LLMs 5GB) | Test 2 (Self-host vs API) | Test 3 (RAG vs LC) |
+|---|---|---|---|
+| Primary sources | 1/9 (11%) | 0/10 (0%) | **4/6 (67%)** |
+| Secondary | 7/9 (78%) | 7/10 (70%) | 2/6 (33%) |
+| Tertiary | 1/9 (11%) | 3/10 (30%) | **0/6 (0%)** |
+| Distribution | Acceptable | **Weak** (flagged) | **Healthy** |
+| Refute claims | 1 | 4 | 5 |
+
+**What this validated:**
+
+1. **The quality distribution check actively steers search strategy.** When the agent knows it must report the distribution (healthy/acceptable/weak), it prioritizes primary sources (arXiv, vendor research) over secondary blogs. Test 2 landed at "weak" (0 primary); Test 3 landed at "healthy" (67% primary) because the search was deliberately structured to find primary sources.
+
+2. **Tertiary sources are not always needed.** Test 2 used Reddit for refute counter-evidence (appropriate). Test 3 found all refute evidence in primary research (Chroma's context rot, arXiv papers) — zero tertiary needed. The methodology doesn't force tertiary; it forces the right tier for each claim type.
+
+3. **Conflict resolution by quality applied in practice.** When NIAH scores (vendor-cited, secondary) conflicted with RULER scores (NVIDIA research, primary), the report presented RULER as the stronger finding and NIAH as the limited benchmark — per the "primary > secondary" rule. This wasn't abstract; it resolved a real source conflict.
+
+4. **Weighting notes per claim tier.** The report explicitly stated which claims rest on which tier: core accuracy findings on 3× primary arXiv papers, cost figures on 2× secondary (with a gap note that the exact 1,250× multiplier is secondhand). This gives the reader evidence-strength transparency that a flat source table doesn't.
+
+5. **Contextual AI bias acknowledged.** The "RAG is irreplaceable" claim came from Contextual AI (founded by the RAG inventor) — primary authority with an inherent pro-RAG bias. The report noted this and corroborated with independent arXiv papers and adoption data. Primary sources can be biased too; the weighting system handles this via corroboration requirements.
+
+**Key lesson:** The source quality ranking is not just a labeling exercise — it changes how the agent searches, how it resolves conflicts, and how it presents evidence strength. The distribution check (healthy/acceptable/weak) is the enforcement mechanism that makes the ranking actionable.
+
 ## What NOT to Adopt from sn-deep-research
 
 - **Full 9-role multi-agent dispatch** — 9 agent invocations = massive token/latency overhead. Our single-agent loop with evidence.json is sufficient.


### PR DESCRIPTION
## What

Ports pere-toolkit's canonical four-label evidence discipline into `deep-research`, adapted for research **facts** (not financial figures).

## Labels

| Label | A fact is `[LABEL]` when… |
|---|---|
| `[VERIFIED]` | corroborated across ≥2 independent, cited, dated sources |
| `[SOURCED]` | stated by one named source, not independently corroborated |
| `[REASONED]` | analytical judgement / inference — not stated by any source |
| `[ESTIMATED]` | a calculation or stated assumption |

## How it threads through the loop

- **§3c Extraction** — grade each material fact's basis as you extract
- **§3d Synthesis** — carry tags in research state; promote `[SOURCED]`→`[VERIFIED]` on ≥2 independent corroborating sources during dedup
- **§4 Final Report** — render tags inline; paste an **Evidence key** legend below the Sources table so the tags decode
- **Fallback report** — keep each finding's tag even on raw compilation
- **New pitfalls** — improvised labels, overclaiming basis, restating precision the source didn't give

## Composes with v1.3.0 (does not replace it)

The v1.3.0 source-quality tiers (`primary`/`secondary`/`tertiary`) classify the **source**; the new evidence-basis labels classify the **fact**. They are orthogonal:

- A fact from one primary source → `[SOURCED]` (strong source, uncorroborated)
- The same fact from two independent primary sources → `[VERIFIED]`

The skill uses both: tier in the source table, label inline on each claim. The relationship is explicitly documented in §3c.

## Also includes

- `references/structured-evidence-format.md` — adds the **Third Validation: Source Quality Ranking Stress Test (July 2026)** section that documents how the quality-distribution check steers search strategy (was uncommitted in the standalone skill; now published).
- Routing fixture updated to require evidence-basis tags + key in `required_output_fields`.
- README descriptions updated.

## Prompt-level only

No Stop-hook enforcement (the public skill has no equivalent of pere's `memo_qa`); faithful to the spirit, not machine-gated.

## Tests

```
tests/test_routing_fixtures.py — 5 passed
frontmatter + JSON fixture validate
```

Skill version: 1.3.0 → **1.4.0**.