### PR TITLE
Add optional Atlas Cloud image generation skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ agent_skills/
 ├── LICENSE
 ├── creative/                         ← image and video generation workflows
 │   ├── image-studio/                 ← staged fal.ai image generation/editing/cleanup
+│   ├── atlas-image-generation/       ← opt-in Atlas Cloud text-to-image with live schema validation
 │   ├── clips-studio/                 ← staged fal.ai short-video generation/animation/camera moves
 │   └── pexels-stock-photos/          ← free real-world stock photo search + download (Pexels API)
 ├── research/                         ← source-grounded research, enrichment, and RAG skills
@@ -59,6 +60,7 @@ New skills are added as folders under the relevant domain directory.
 | Skill | Domain | What it does | Pairs with |
 |-------|--------|-------------|------------|
 | [image-studio](creative/image-studio/) | creative | Staged fal.ai image gen/edit/upscale/cleanup with cost logging + `--dry-run` | pexels-stock-photos |
+| [atlas-image-generation](creative/atlas-image-generation/) | creative | Opt-in Atlas Cloud text-to-image with live model/schema validation + one-submit safety | pexels-stock-photos, image-studio |
 | [clips-studio](creative/clips-studio/) | creative | Staged fal.ai short-video: text-to-video, animate still, camera moves | image-studio |
 | [pexels-stock-photos](creative/pexels-stock-photos/) | creative | Free real-world stock photos (Pexels API, 20k/month) with attribution handling | image-studio |
 | [deep-research](research/deep-research/) | research | Iterative research engine: structured evidence, source quality ranking (primary/secondary/tertiary), refute polarity, overview-first reports, four-label evidence-basis discipline ([VERIFIED]/[SOURCED]/[REASONED]/[ESTIMATED]) | fact-checker, source-tracker |
@@ -95,6 +97,7 @@ New skills are added as folders under the relevant domain directory.
 | Skill | Status | Tests | Dependencies |
 |-------|--------|-------|-------------|
 | image-studio | Stable | ✓ | fal.ai key |
+| atlas-image-generation | Beta | ✓ | Atlas Cloud API key |
 | clips-studio | Stable | ✓ | fal.ai key |
 | pexels-stock-photos | Stable | ✓ | Pexels API key (free) |
 | deep-research | Stable | evals, references | None (prompt-only) |

--- a/creative/atlas-image-generation/README.md
+++ b/creative/atlas-image-generation/README.md
@@ -1,0 +1,35 @@
+# atlas-image-generation
+
+Opt-in text-to-image generation through Atlas Cloud. The dependency-free Python
+helper validates the selected model against the live public catalog and schema,
+submits one paid request without retrying it, polls with bounded GET retries,
+and validates the downloaded image.
+
+## Requirements
+
+- Python 3.11+
+- `ATLASCLOUD_API_KEY` in the environment
+- No third-party Python dependencies
+
+## Quick check
+
+```bash
+python scripts/generate_image.py \
+  "A red paper kite above a green field" \
+  --aspect-ratio 16:9 --resolution 1k \
+  --output ./outputs/kite.png --dry-run
+```
+
+`--dry-run` performs no network calls. Remove it only after confirming the
+prompt, external egress, and current Atlas Cloud price.
+
+## Tests
+
+```bash
+python -m pytest creative/atlas-image-generation/tests/test_generate_image.py -q
+```
+
+## License
+
+MIT
+

--- a/creative/atlas-image-generation/SKILL.md
+++ b/creative/atlas-image-generation/SKILL.md
@@ -1,0 +1,79 @@
+---
+name: atlas-image-generation
+description: >
+  Generate an AI image through Atlas Cloud when the user explicitly chooses
+  Atlas Cloud or provides ATLASCLOUD_API_KEY. Uses a live public model catalog
+  and schema check, one non-retried paid submission, bounded GET polling, and
+  local image validation. Do not use for stock-photo search, image editing, or
+  when the host requires its native image tool.
+license: MIT
+metadata:
+  version: 1.0.0
+  author: binyangzhu000-sudo
+  platforms: [linux, macos, windows]
+  tags: [image-generation, atlas-cloud, text-to-image]
+  related_skills: [image-studio, pexels-stock-photos]
+---
+
+# Atlas Image Generation
+
+Generate one image through Atlas Cloud and save it locally. This is an opt-in
+provider route: keep `image-studio` as the fal.ai workflow, and use
+`pexels-stock-photos` when the user wants a real stock photo.
+
+## Before the paid request
+
+1. Confirm that the user chose Atlas Cloud and accepts third-party egress.
+2. Confirm the prompt contains no confidential or sensitive information.
+3. Set `ATLASCLOUD_API_KEY` in the environment; never place it in arguments,
+   files, logs, or committed content.
+4. Run `--dry-run` to inspect the request without making any network call.
+5. Review the current model and price in the Atlas Cloud catalog. The default
+   model was verified against the live catalog and schema on 2026-08-31, but
+   model availability, fields, and pricing can change.
+
+## Generate
+
+Run from this skill directory:
+
+```bash
+export ATLASCLOUD_API_KEY="..."
+python scripts/generate_image.py \
+  "Editorial illustration of a solar-powered city block, clean geometric forms" \
+  --aspect-ratio 16:9 \
+  --resolution 1k \
+  --output ./outputs/solar-city.png \
+  --dry-run
+```
+
+Remove `--dry-run` only after the user approves the prompt and cost. The helper:
+
+- fetches the public model catalog and the selected model's live schema;
+- rejects hidden, non-image, missing, or incompatible models;
+- submits the paid generation POST exactly once, with no automatic retry;
+- polls prediction status using bounded GET retries;
+- downloads the first output and validates PNG, JPEG, or WebP bytes before
+  writing the destination file.
+
+The default model is
+`google/nano-banana-pro/text-to-image-developer`. Override it with `--model`
+only when the live schema supports the supplied options.
+
+## Cost and retry safety
+
+- A generation POST is billable and must never be retried automatically.
+- A failed or ambiguous submission is reported to the user; do not submit a
+  replacement request without fresh confirmation.
+- Only catalog, schema, and prediction GET requests use bounded retries.
+- Use one image for the first run. Batch generation belongs in a separately
+  approved workflow with an explicit budget.
+
+## Verification
+
+After completion, check that:
+
+- the printed output path exists and is non-empty;
+- the file opens as the expected image;
+- its composition matches the approved prompt;
+- no key, temporary URL, or local absolute path was written into tracked files.
+

--- a/creative/atlas-image-generation/scripts/generate_image.py
+++ b/creative/atlas-image-generation/scripts/generate_image.py
@@ -1,0 +1,215 @@
+#!/usr/bin/env python3
+"""Generate one image through Atlas Cloud without retrying the paid POST."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+import time
+import urllib.error
+import urllib.parse
+import urllib.request
+from pathlib import Path
+from typing import Any
+
+
+CATALOG_URL = "https://api.atlascloud.ai/api/v1/models"
+DEFAULT_API_BASE = "https://api.atlascloud.ai/api/v1"
+DEFAULT_MODEL = "google/nano-banana-pro/text-to-image-developer"
+SUCCESS_STATUSES = {"completed", "succeeded", "success"}
+FAILURE_STATUSES = {"failed", "canceled", "cancelled"}
+USER_AGENT = "agent-skills-atlas-image/1.0"
+
+
+def read_json(request: urllib.request.Request, timeout: float) -> dict[str, Any]:
+    try:
+        with urllib.request.urlopen(request, timeout=timeout) as response:
+            return json.loads(response.read().decode("utf-8"))
+    except urllib.error.HTTPError as exc:
+        detail = exc.read().decode("utf-8", errors="replace")
+        raise RuntimeError(f"HTTP {exc.code}: {detail}") from exc
+
+
+def get_json(
+    url: str,
+    *,
+    headers: dict[str, str] | None = None,
+    attempts: int = 3,
+    timeout: float = 30,
+) -> dict[str, Any]:
+    last_error: Exception | None = None
+    for attempt in range(attempts):
+        request_headers = {"User-Agent": USER_AGENT, **(headers or {})}
+        request = urllib.request.Request(url, headers=request_headers)
+        try:
+            return read_json(request, timeout)
+        except (RuntimeError, urllib.error.URLError, json.JSONDecodeError) as exc:
+            last_error = exc
+            if attempt + 1 < attempts:
+                time.sleep(2**attempt)
+    raise RuntimeError(f"GET failed after {attempts} attempts: {url}") from last_error
+
+
+def validate_live_model(model_id: str, requested_fields: set[str]) -> None:
+    catalog = get_json(CATALOG_URL)
+    models = catalog.get("data") or []
+    model = next((item for item in models if item.get("model") == model_id), None)
+    if not model:
+        raise RuntimeError(f"Model is not present in the live catalog: {model_id}")
+    if model.get("display_console") is not True:
+        raise RuntimeError(f"Model is not public: {model_id}")
+    if model.get("type") != "Image":
+        raise RuntimeError(f"Model is not an image model: {model_id}")
+
+    schema_url = model.get("schema")
+    if not schema_url:
+        raise RuntimeError(f"Model has no live schema: {model_id}")
+    schema = get_json(str(schema_url))
+    properties = (
+        schema.get("components", {}).get("schemas", {}).get("Input", {}).get("properties", {})
+    )
+    missing = sorted(requested_fields - set(properties))
+    if missing:
+        raise RuntimeError(f"Live model schema does not support: {', '.join(missing)}")
+
+
+def first_output_url(data: dict[str, Any]) -> str:
+    outputs = data.get("outputs") or data.get("output") or []
+    if isinstance(outputs, str):
+        return outputs
+    if isinstance(outputs, list) and outputs:
+        first = outputs[0]
+        if isinstance(first, str):
+            return first
+        if isinstance(first, dict):
+            for key in ("url", "image_url"):
+                if isinstance(first.get(key), str):
+                    return first[key]
+    raise RuntimeError("Atlas prediction completed without an output URL")
+
+
+def generate(
+    *,
+    api_key: str,
+    payload: dict[str, Any],
+    api_base: str,
+    poll_interval: float,
+    wait_timeout: float,
+) -> str:
+    headers = {
+        "Authorization": f"Bearer {api_key}",
+        "Content-Type": "application/json",
+        "User-Agent": USER_AGENT,
+    }
+    request = urllib.request.Request(
+        f"{api_base.rstrip('/')}/model/generateImage",
+        data=json.dumps(payload).encode("utf-8"),
+        headers=headers,
+        method="POST",
+    )
+
+    # This POST may be billable and is intentionally never retried.
+    submission = read_json(request, timeout=300)
+    if submission.get("code") not in (None, 200, "200"):
+        raise RuntimeError(str(submission.get("msg") or submission.get("message") or submission))
+    prediction_id = (submission.get("data") or {}).get("id")
+    if not prediction_id:
+        raise RuntimeError("Atlas submission did not return data.id")
+
+    poll_url = (
+        f"{api_base.rstrip('/')}/model/prediction/"
+        f"{urllib.parse.quote(str(prediction_id), safe='')}"
+    )
+    deadline = time.monotonic() + wait_timeout
+    while time.monotonic() < deadline:
+        prediction = get_json(
+            poll_url,
+            headers={"Authorization": f"Bearer {api_key}"},
+        )
+        data = prediction.get("data") or {}
+        status = str(data.get("status") or "").lower()
+        if status in SUCCESS_STATUSES:
+            return first_output_url(data)
+        if status in FAILURE_STATUSES:
+            reason = data.get("error") or data.get("message") or status
+            raise RuntimeError(f"Atlas image generation failed: {reason}")
+        time.sleep(poll_interval)
+    raise RuntimeError(f"Timed out waiting for Atlas prediction {prediction_id}")
+
+
+def detect_image(data: bytes) -> str:
+    if data.startswith(b"\x89PNG\r\n\x1a\n"):
+        return "PNG"
+    if data.startswith(b"\xff\xd8\xff"):
+        return "JPEG"
+    if len(data) >= 12 and data[:4] == b"RIFF" and data[8:12] == b"WEBP":
+        return "WebP"
+    raise RuntimeError("Downloaded Atlas output is not a PNG, JPEG, or WebP image")
+
+
+def download_image(url: str, output: Path) -> str:
+    request = urllib.request.Request(url, headers={"User-Agent": USER_AGENT})
+    try:
+        with urllib.request.urlopen(request, timeout=180) as response:
+            data = response.read()
+    except urllib.error.URLError as exc:
+        raise RuntimeError(f"Image download failed: {exc}") from exc
+    image_type = detect_image(data)
+    output.parent.mkdir(parents=True, exist_ok=True)
+    output.write_bytes(data)
+    return image_type
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Generate one image through Atlas Cloud.")
+    parser.add_argument("prompt", help="Text prompt sent to the selected image model")
+    parser.add_argument("--model", default=DEFAULT_MODEL)
+    parser.add_argument(
+        "--aspect-ratio",
+        choices=("1:1", "3:2", "2:3", "3:4", "4:3", "4:5", "5:4", "9:16", "16:9", "21:9"),
+    )
+    parser.add_argument("--resolution", choices=("1k", "2k", "4k"))
+    parser.add_argument("--seed", type=int)
+    parser.add_argument("--output", type=Path, default=Path("atlas-image.png"))
+    parser.add_argument("--poll-interval", type=float, default=5)
+    parser.add_argument("--timeout", type=float, default=600)
+    parser.add_argument("--dry-run", action="store_true", help="Print the payload; do not use the network")
+    return parser
+
+
+def main() -> int:
+    args = build_parser().parse_args()
+    payload: dict[str, Any] = {"model": args.model, "prompt": args.prompt}
+    optional = {
+        "aspect_ratio": args.aspect_ratio,
+        "resolution": args.resolution,
+        "seed": args.seed,
+    }
+    payload.update({key: value for key, value in optional.items() if value is not None})
+
+    if args.dry_run:
+        print(json.dumps(payload, indent=2, ensure_ascii=False))
+        return 0
+
+    api_key = os.environ.get("ATLASCLOUD_API_KEY", "").strip()
+    if not api_key:
+        print("Missing ATLASCLOUD_API_KEY", file=sys.stderr)
+        return 2
+
+    validate_live_model(args.model, set(payload))
+    output_url = generate(
+        api_key=api_key,
+        payload=payload,
+        api_base=os.environ.get("ATLASCLOUD_API_BASE_URL", DEFAULT_API_BASE),
+        poll_interval=args.poll_interval,
+        wait_timeout=args.timeout,
+    )
+    image_type = download_image(output_url, args.output)
+    print(f"{args.output} ({image_type})")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/creative/atlas-image-generation/tests/test_generate_image.py
+++ b/creative/atlas-image-generation/tests/test_generate_image.py
@@ -1,0 +1,82 @@
+import importlib.util
+import json
+import subprocess
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+
+SCRIPT = Path(__file__).resolve().parent.parent / "scripts" / "generate_image.py"
+SPEC = importlib.util.spec_from_file_location("atlas_generate_image", SCRIPT)
+MODULE = importlib.util.module_from_spec(SPEC)
+assert SPEC.loader is not None
+SPEC.loader.exec_module(MODULE)
+
+
+class FakeResponse:
+    def __init__(self, payload):
+        self.payload = payload
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *_args):
+        return False
+
+    def read(self):
+        if isinstance(self.payload, bytes):
+            return self.payload
+        return json.dumps(self.payload).encode("utf-8")
+
+
+def test_paid_submission_happens_once_then_poll_completes():
+    responses = [
+        FakeResponse({"code": 200, "data": {"id": "prediction-test"}}),
+        FakeResponse({"code": 200, "data": {"status": "processing"}}),
+        FakeResponse(
+            {
+                "code": 200,
+                "data": {"status": "completed", "outputs": ["https://example.test/image.png"]},
+            }
+        ),
+    ]
+    with patch.object(MODULE.urllib.request, "urlopen", side_effect=responses) as urlopen:
+        output = MODULE.generate(
+            api_key="test-key",
+            payload={"model": "example/image", "prompt": "red kite"},
+            api_base="https://example.test/api/v1",
+            poll_interval=0,
+            wait_timeout=2,
+        )
+
+    assert output == "https://example.test/image.png"
+    requests = [call.args[0] for call in urlopen.call_args_list]
+    assert sum(request.get_method() == "POST" for request in requests) == 1
+    for request in requests[1:]:
+        assert request.get_header("Authorization") == "Bearer test-key"
+
+
+def test_dry_run_uses_no_api_key_or_network():
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(SCRIPT),
+            "red kite",
+            "--aspect-ratio",
+            "16:9",
+            "--dry-run",
+        ],
+        check=True,
+        capture_output=True,
+        text=True,
+        env={},
+    )
+    payload = json.loads(result.stdout)
+    assert payload["prompt"] == "red kite"
+    assert payload["aspect_ratio"] == "16:9"
+
+
+def test_detect_image_signatures():
+    assert MODULE.detect_image(b"\x89PNG\r\n\x1a\nrest") == "PNG"
+    assert MODULE.detect_image(b"\xff\xd8\xffrest") == "JPEG"
+    assert MODULE.detect_image(b"RIFFxxxxWEBPrest") == "WebP"

--- a/creative/pexels-stock-photos/SKILL.md
+++ b/creative/pexels-stock-photos/SKILL.md
@@ -30,7 +30,7 @@ photographer and link to Pexels.
 |--------------|------|
 | "find a photo of Singapore" / "search for office pictures" / "stock image of a desk" | **Pexels** (this skill) |
 | "I need a real photo for this slide" / "find pictures for my article" | **Pexels** (this skill) |
-| "generate an image of a cat" / "create a picture of..." / "make me an illustration" | Host's image generation tool |
+| "generate an image of a cat" / "create a picture of..." / "make me an illustration" | `atlas-image-generation` when Atlas Cloud is explicitly selected; otherwise the host's image tool or `image-studio` |
 | "upscale this" / "remove background" / "edit: make warmer" | Host's AI image editing skill |
 | "production-ready hero image" / "let's do this properly" | Host's multi-stage image generation skill |
 
@@ -47,7 +47,7 @@ or **find/search** → Pexels. If the user says **generate**, **create**, **make
 - Any request for "real" images vs AI-generated
 
 **Don't use for:**
-- AI art / creative generation → host's image generation tool
+- AI art / creative generation → `atlas-image-generation` when Atlas Cloud is explicitly selected; otherwise the host's image tool or `image-studio`
 - Editing existing images → host's image editing skill
 - Screenshots or diagrams → use appropriate tools
 


### PR DESCRIPTION
## Summary

- add a self-contained, opt-in Atlas Cloud text-to-image skill
- validate the selected model against the live public catalog and schema
- submit the billable generation POST exactly once, then use bounded GET polling
- validate downloaded PNG, JPEG, or WebP bytes before writing
- route explicit Atlas Cloud generation requests from the Pexels decision table

## Safety

- `--dry-run` performs no network calls
- the API key is read only from `ATLASCLOUD_API_KEY`
- the paid POST is never retried automatically
- Atlas Cloud remains optional and does not replace existing providers

## Verification

- `python3 -m pytest creative/atlas-image-generation/tests/test_generate_image.py creative/pexels-stock-photos/tests/test_skill.py -q` (27 passed)
- `npx --yes skills-ref validate creative/atlas-image-generation`
- one live 1K smoke generation completed and produced a valid JPEG

The repository-wide test collection was also attempted, but the current local Python version cannot evaluate existing PEP 604 annotations in several unrelated skills.