### PR TITLE
Add input-token-analysis skill + wire 30-day audit cron into onboarding

### DIFF
--- a/agent-ops/hermes-onboarding/SKILL.md
+++ b/agent-ops/hermes-onboarding/SKILL.md
@@ -361,13 +361,14 @@ hermes config set cron.model <main-model>
 
 ## Step 18 — Maintenance crons
 
-Create 3 scheduled crons + document 1 triggered procedure:
+Create 4 scheduled crons + document 1 triggered procedure:
 
 | Cron | Schedule | Mode | What |
 |------|----------|------|------|
 | Memory consolidation | Every 4 days, 02:00 | no_agent | `mnemosyne_sleep.sh` — working memory → episodic. Silent when done. |
 | Backup + update + health | Weekly (Sun, 03:00) | Agent | `hermes backup` (max 2 copies), then `hermes update`, then post-update health check (re-apply LAN patches if needed). Alert on failure. |
 | Weekly health check | Weekly (Sun, 06:00) | no_agent | `weekly_health_check.sh` — consolidated report: host status, disk usage, log anomalies, input token overhead. Silent when healthy. Alerts with breakdown when any check finds issues. |
+| Input token audit | Every 30 days, 09:30 | Agent | Run the `input-token-analysis` skill (`scripts/audit.py --days 30`): rank consumers, pre-check levers, report deltas vs the prior baseline, propose changes with verified config values. Delivers a full report each run — the deep audit the weekly check only samples. Requires the `input-token-analysis` skill installed (see Step 20). |
 
 The backup+update cron runs in agent mode (not no_agent) because the post-update health check may need to re-apply dashboard patches that `hermes update` overwrites. A no_agent script cannot re-apply patches or run `skill_view`.
 
@@ -404,7 +405,26 @@ chmod +x ~/.hermes/scripts/weekly_health_check.sh
 
 Triggered (not scheduled): post-update health check — run `hermes doctor`, verify gateway + dashboard status, re-apply patches if needed. See `references/setup-details.md` § Post-update health check. Also triggered manually after any `hermes update` outside the weekly cron.
 
-**Done:** 3 crons created. Weekly health check script installed. Post-update procedure documented.
+Create the input-token audit cron (agent mode — it needs `skill_view` and reasoning):
+
+```
+Prompt skeleton (adapt to the customer):
+
+"You are the input-token auditor. Load the `input-token-analysis` skill and run
+its scripts/audit.py for the last 30 days. Compare against the previous audit's
+baseline (read it from the prior cron output if available, else establish this
+run as the first baseline). Pre-check every lever before proposing changes:
+read current values with `hermes config get`, confirm mechanisms against
+config_defaults.py or the Hermes docs, mark unverifiable claims UNVERIFIED.
+Report under 600 words: (1) total vs baseline with % change, (2) breakdown by
+task, (3) verdict on any previously applied changes with proving numbers,
+(4) top 3 remaining consumers, (5) one recommended next tweak citing the
+pre-checked current value."
+
+Schedule: every 30 days. Delivery: customer's home channel.
+```
+
+**Done:** 4 crons created. Weekly health check script installed. Post-update procedure documented.
 
 ## Step 19 — Verification summary
 
@@ -420,8 +440,9 @@ Triggered (not scheduled): post-update health check — run `hermes doctor`, ver
 | Search | `web_search` test query returns results |
 | Extraction | `web_extract` test URL returns content |
 | Browser | CDP browser opens and navigates |
-| Crons | `hermes cron list` shows 3 jobs |
+| Crons | `hermes cron list` shows 4 jobs |
 | Weekly health check | `~/.hermes/scripts/weekly_health_check.sh` exists and is executable |
+| Input token audit | `hermes cron list` shows a 30-day audit job; `input-token-analysis` skill installed and `scripts/audit.py` runs |
 | Timezone | `hermes config get timezone` matches customer input |
 | Approvals | `hermes config get approvals.mode` returns `smart` |
 | Terminal backend | `hermes config get terminal.backend` matches detection |
@@ -454,7 +475,9 @@ hermes skills search <use-case-keyword>
 
 Install customer's chosen skills: `hermes skills install <id>`
 
-**Done:** use case recorded. Relevant skills recommended and installed.
+Also install the `input-token-analysis` skill from this repo (`agent-ops/input-token-analysis`) — the 30-day audit cron from Step 18 depends on it.
+
+**Done:** use case recorded. Relevant skills recommended and installed. Input-token-analysis skill installed for the Step 18 audit cron.
 
 ## Common Pitfalls
 

--- a/agent-ops/input-token-analysis/SKILL.md
+++ b/agent-ops/input-token-analysis/SKILL.md
@@ -1,0 +1,120 @@
+---
+name: input-token-analysis
+description: "Use when input token spend needs explaining and fixing."
+license: MIT
+metadata:
+  version: 1.2.0
+  author: moonlight-lupin
+  platforms: [linux]
+  tags: [tokens, audit, cost, accounting, agent-ops]
+  related_skills: [input-token-overheads, skill-maintainer]
+---
+
+# Input Token Analysis
+
+Explain aggregate input token consumption. Answer three questions with numbers: where did the tokens go, which consumers dominate, what config or prompt change reduces them. Distinct from `input-token-overheads`, which audits per-turn system-prompt blocks. This skill audits total volume across sessions, cron fires, and tool traffic.
+
+## When to Use
+
+- Monthly/weekly input token bill is large and unexplained (e.g. "2.4B tokens in 30 days")
+- After applying token-saving changes — measure the delta against a baseline
+- A cron job is suspected of runaway token use
+
+For per-turn context-window health, use `input-token-overheads`. For API billing disputes, use the provider's usage dashboard — local telemetry cannot see provider-side caching.
+
+## Quick Start
+
+Run the audit script (read-only, pure stdlib):
+
+```bash
+python3 ~/.hermes/skills/agent-ops/input-token-analysis/scripts/audit.py --days 30
+# other profiles: --db ~/.hermes/profiles/<name>/state.db
+# custom cron ledger: --cron-audit /path/to/usage_audit.jsonl --jobs /path/to/jobs.json
+```
+
+The script prints: totals by task/model/provider, cache-read and cache-write columns, weighted per-call averages (long sessions and short-session floor), top sessions, cron offenders, active-only tool-result volume with the tool-share percentage, and oversized-result counts. Everything is derived from real DB rows — never estimate by hand when the script can measure.
+
+## Pre-Check Discipline
+
+Verify before advising. Advice formed from memory is not acceptable.
+
+1. **Config keys and current values** — read the live value first: `hermes config get <key>`. Never state a current value from memory or assume the default is in force.
+2. **Defaults and mechanisms** — confirm a key exists and what it does against the installed build (`hermes_cli/config_defaults.py`) or the Hermes docs. If the installed build and docs disagree, say so.
+3. **Provider behavior** — do not assume a provider reports cache fields, honors a pricing tier, or counts tokens a certain way. Probe it or check its current docs before claiming.
+4. **Unverifiable claims** — mark them UNVERIFIED in the report. A labeled unknown beats a confident guess.
+
+A proposal that cites an unverified key, value, or mechanism is incomplete. Complete the pre-check or drop the proposal.
+
+## Interpretation
+
+Rank consumers, then map each to a pre-checked lever:
+
+| Finding | Signal | Lever |
+|---------|--------|-------|
+| Long sessions dominate | Top sessions >200 api_calls, >40M input | First check the provider's cache discount. With caching, a warm session re-reads history cheaply; reset only when uncached dead weight dominates. Every reset re-pays the full prefix at full price. Check compression actually fires (compact count >0) |
+| background_review large | task='background_review' >5% of total | `auxiliary.background_review.max_input_tokens` (default 600000) or `enabled: false`; manual `/refine` still works. Also route `auxiliary.background_review.model` to a cheaper model — a different model replays a compact digest instead of the full transcript |
+| One cron job dominates | avg prompt_tokens/fire in the millions | Rewrite its prompt with a read budget: date-bounded source data, skip oversized items, narrow scroll windows, stop-at-cap and defer |
+| Cron cost at the floor | avg tokens/fire near the per-call floor (25-30k) | The fixed scaffolding floor times fire count dominates: reduce fire frequency or merge jobs rather than shrinking prompts |
+| Tool results dominate context | tool chars >70% of STORED active content (upper bound on sent; script prints the share) | `tool_output.max_bytes` (default 50000), `file_read_max_chars` (default 100000), spillover budget. Under provider caching, savings concentrate on the first turn a result appears and on compression avoidance — stable results re-read via cache are cheap. Oversized results spill to `$HERMES_HOME/cache/spillover/` as preview + path |
+| Duplicate skill loads | same skill body loaded N times per session | Behavioral rule: never re-call skill_view for a skill already in context. Under caching the direct re-read is discounted; the real damage is context pressure triggering earlier compression, which busts the cache |
+| High per-call floor at short sessions | script's weighted avg for <50-call sessions (typically 25-40k) | Fixed baseline (system prompt + tool schemas) — reduce via `input-token-overheads`, not this skill |
+| Subagent fan-out heavy | many delegate_task spawns; each re-pays the full system prompt + tool schemas uncached | Route `delegation.model` to a cheaper model for mechanical subtasks; batch tool calls into one execute_code call instead of fanning out; cap concurrent subagents |
+| Compression firing often | compression events per session high; `compression_ineffective_count` >0 | Each compression rewrites history into a new prefix = full-price cache miss for everything after. Weigh `compression.threshold` against the provider's cache discount; route the compression summarizer (`auxiliary.compression.model`) to a cheap model — it reads the entire conversation |
+| cache_read ≈ 0 on a provider | provider emits no cached-token field at all (then local input IS the full prompt and share is unmeasurable — check the provider's billing dashboard), vs provider reports the field but it is 0 (caching genuinely off: short sessions, unstable prefix, or TTL expiry — investigate) |
+| Cheap-task traffic on premium models | title_generation/approval/vision rows on the main model | Route each `auxiliary.<task>.model` to a flash-class model; near-free savings on frequent small calls |
+| Token ranking ≠ cost ranking | a cheap model consumes 10x the tokens of a premium one | Rank by `estimated_cost_usd`/`actual_cost_usd` per billing_provider; exclude `billing_mode='subscription_included'` rows (zero marginal cost) from optimization effort |
+
+## Procedure
+
+### 1. Establish the baseline
+
+Run the script for the window in question. Record: total input, per-task breakdown, top-10 sessions, cron offender stats, tool-char share, cache columns, cost totals. Save the output next to the changes you plan to make.
+
+Done when: every number in the final report traces to a script line.
+
+### 2. Pre-check each candidate lever
+
+Before any lever enters a proposal, verify it on the live instance: key exists (`hermes config get`), current value known, mechanism matches the installed build or docs. Check the provider's reporting behavior before making cache-related claims.
+
+Done when: every lever in the draft proposal has a verified key + current value, or is marked UNVERIFIED with what is missing.
+
+### 3. Rank and map
+
+Order consumers by tokens AND by estimated cost (they can disagree). For each of the top 3, name the pre-checked lever. If a consumer maps to no lever, say so explicitly instead of inventing one.
+
+Done when: top 3 consumers each have a pre-checked lever or an explicit "no local lever" verdict.
+
+### 4. Propose changes
+
+Proposals in impact order, each with: config key or prompt edit, expected saving, revert path. Compute expected saving per billing_provider with that provider's cache discount applied; where the provider does not report cache fields, state the estimate is bounded and verify on the provider dashboard. Config edits go through `hermes config set` — direct file edits to config.yaml are blocked by the tooling (verified 2026-09-02). Cron prompt edits: back up the old prompt first, edit, then verify shape (`{"jobs": [...], "updated_at": ...}`) and schedules survived.
+
+Done when: the user approved each change and it is applied AND read back verified.
+
+### 5. Schedule the delta check
+
+Create a one-shot cron ~30 days out that re-runs this skill with the old baseline in its prompt. Include: baseline numbers, the list of applied changes, and per-change pass criteria (e.g. "job X avg prompt_tokens/fire >2M = not fixed").
+
+Done when: the delta-check cron exists (`hermes cron list` shows it) and its prompt contains the baseline numbers, applied-change list, and pass criteria.
+
+## Pitfalls
+
+1. **Open state.db read-only** (`file:...?mode=ro`, uri=True, URL-encode the path). It is live and can be hundreds of MB; a writer connection risks locks.
+2. **input_tokens semantics differ by provider wire format.** Anthropic-style wires report `cache_read_tokens` IN ADDITION to input (true prompt ≈ input + cache_read + cache_write); OpenAI-style `prompt_tokens` includes cached tokens as a subset. Empirical check: if cache_read > input_tokens for a row, that provider excludes cache from input. Never compare raw input_tokens across providers; compute effective prompt per billing_provider. The cache-share ratio is only meaningful within one convention.
+3. **jobs.json has two observed shapes** — `{"jobs": [...], "updated_at": ...}` and a bare list. Handle both before and after editing; verify the container shape after any write.
+4. **Cache-share 0 does not prove no caching.** Some providers return no cached-token field in `usage` at all (one such provider verified 2026-09-02 — its usage object carried only prompt/completion/total), so local telemetry is blind to their caching. Others report cache reads per call. Check each provider's docs and billing dashboard for ground truth.
+5. **sessions.input_tokens and session_model_usage differ by attribution**, not just timing: task rows are cumulative per session and attributed by last_seen (pulling pre-window spend into the window), while per-session ranking uses start/activity dates. State the skew direction when totals do not reconcile; never mix the two totals in one sum.
+6. **token_count column is often NULL** — measure content size with LENGTH(), and remember chars ≈ tokens/4 only as a rough proxy.
+7. **Compaction and inactivity skew stored content.** Filter messages by `active=1`: compacted rows were replaced by summaries and inactive rows are no longer sent. Stored active content is still an upper bound on sent content (truncation already applied at capture time). Live-vs-compacted splits explain why a session's DB size can exceed its context.
+8. **A single fire can dwarf everything** — scan for max(prompt_tokens) in the cron ledger before averaging; one multi-million-token fire hides inside a healthy-looking mean.
+9. **Cron ledger prompt_tokens semantics are per-fire and under-documented** — one line per fire, but an agentic fire makes many API calls with context re-sent each call. Treat avg tokens/fire as a lower bound on true cron input and verify against a fire's session rows when precision matters.
+10. **Per-call averages must be weighted** — SUM(input)/SUM(calls), never AVG of per-session ratios; a 200-call session and a 10,000-call session count equally otherwise.
+
+## Verification Checklist
+
+- [ ] Script ran read-only against every relevant profile DB (default + any active profiles)
+- [ ] Totals cross-checked with attribution skew stated (task rows by last_seen vs sessions by start/activity)
+- [ ] Each top consumer mapped to a pre-checked lever or marked "no local lever"
+- [ ] Every proposed lever pre-checked: key exists, current value read live, mechanism confirmed
+- [ ] Applied changes read back verified (`hermes config get`, cron jobs.json re-parse)
+- [ ] Old prompts/config backed up with paths recorded
+- [ ] Delta-check cron scheduled with baseline + pass criteria in its prompt

--- a/agent-ops/input-token-analysis/scripts/audit.py
+++ b/agent-ops/input-token-analysis/scripts/audit.py
@@ -1,0 +1,198 @@
+#!/usr/bin/env python3
+"""Aggregate input-token audit for a Hermes instance.
+
+Read-only: state.db (session_model_usage, sessions, messages) + cron usage ledger.
+Pure stdlib. Prints a report.
+
+Usage:
+  audit.py [--days 30] [--db ~/.hermes/state.db]
+           [--cron-audit ~/.hermes/cron/usage_audit.jsonl] [--jobs ~/.hermes/cron/jobs.json]
+"""
+import argparse
+import collections
+import json
+import os
+import sqlite3
+import sys
+import time
+import urllib.parse
+
+HERMES = os.path.expanduser("~/.hermes")
+
+
+def audit_sessions(db_path, cutoff):
+    if not os.path.exists(db_path):
+        print(f"[sessions] DB not found: {db_path}")
+        return
+    uri = pathlib_uri(db_path) + "?mode=ro"
+    conn = sqlite3.connect(uri, uri=True, timeout=15)
+
+    print(f"\n=== task/model/provider breakdown, window attributed by last_seen ({db_path}) ===")
+    print("  NOTE: task rows are cumulative per session; 'input' semantics vary by provider wire")
+    print("  format (see SKILL.md pitfalls). If cache_read > input for a row, that provider")
+    print("  reports cache IN ADDITION to input: true prompt volume ~ input + cache_read + cache_write.")
+    try:
+        rows = conn.execute("""SELECT task, model, billing_provider, SUM(api_call_count), SUM(input_tokens),
+                                 SUM(output_tokens), SUM(cache_read_tokens), SUM(cache_write_tokens),
+                                 SUM(estimated_cost_usd), SUM(actual_cost_usd), COUNT(*)
+                          FROM session_model_usage WHERE last_seen >= ?
+                          GROUP BY task, model, billing_provider ORDER BY SUM(input_tokens) DESC""",
+                            (cutoff,)).fetchall()
+    except sqlite3.OperationalError as e:
+        print(f"  table missing or error: {e}")
+        conn.close()
+        return
+    tot_in = tot_cr = tot_cw = tot_calls = tot_cost = 0
+    for task, model, prov, calls, it, ot, cr, cw, est, act, n in rows:
+        calls = calls or 0; it = it or 0; cr = cr or 0; cw = cw or 0
+        tot_in += it; tot_cr += cr; tot_cw += cw; tot_calls += calls
+        tot_cost += (act if (act := act or est) is not None else (est or 0)) if False else (act if (act := (act or est)) is not None else 0)
+        avg = it / calls if calls else 0
+        flag = " [cache-added-to-input]" if cr > it and cr > 0 else ""
+        print(f"  {str(task or '(main)'):20} {str(model):26} {str(prov or '-'):14} calls={calls:>6} "
+              f"input={it:>13,} cache_read={cr:>11,} cache_write={cw:>9,} avg/call={avg:>9,.0f}"
+              f" est_usd={(est or 0):>8.2f}{flag}")
+    print(f"  TOTAL input={tot_in:,} cache_read={tot_cr:,} cache_write={tot_cw:,} calls={tot_calls:,}")
+    print("  cache_read is NOT a subset of input on all providers — see note above.")
+
+    print("\n--- top sessions by input (started or active within window) ---")
+    try:
+        rows = conn.execute("""SELECT s.id, s.source, s.chat_type, s.title, s.api_call_count,
+                                 s.input_tokens, s.cache_read_tokens
+                          FROM sessions s
+                          WHERE s.started_at >= ? OR s.last_activity_at >= ?
+                          ORDER BY s.input_tokens DESC LIMIT 10""", (cutoff, cutoff)).fetchall()
+        for sid, src, ct, title, calls, it, cr in rows:
+            flag = " FLAG>40M" if (it or 0) > 40_000_000 else ""
+            flag += " FLAG>200calls" if (calls or 0) > 200 else ""
+            print(f"  {sid} {str(src):8} calls={calls or 0:>5} input={it or 0:>13,} "
+                  f"cr={cr or 0:>10,} {str(title)[:40]!r}{flag}")
+    except sqlite3.OperationalError as e:
+        print(f"  sessions table error: {e}")
+
+    try:
+        # Weighted per-call average: SUM(input)/SUM(calls), not mean of ratios.
+        row = conn.execute("""SELECT SUM(input_tokens)*1.0/SUM(api_call_count), SUM(api_call_count), COUNT(*)
+                         FROM sessions WHERE (started_at>=? OR last_activity_at>=?) AND api_call_count>=200""",
+                          (cutoff, cutoff)).fetchone()
+        if row and row[1]:
+            print(f"\n  weighted avg tokens/call (sessions >=200 calls): {row[0]:,.0f} over {row[1]} calls in {row[2]} sessions")
+        row = conn.execute("""SELECT SUM(input_tokens)*1.0/SUM(api_call_count), SUM(api_call_count), COUNT(*)
+                         FROM sessions WHERE (started_at>=? OR last_activity_at>=?) AND api_call_count < 50""",
+                          (cutoff, cutoff)).fetchone()
+        if row and row[1]:
+            print(f"  weighted avg tokens/call (sessions <50 calls — the fixed-floor case): {row[0]:,.0f} over {row[1]} calls in {row[2]} sessions")
+    except sqlite3.OperationalError:
+        pass
+
+    print("\n--- tool-result volume (ACTIVE messages only; compacted/inactive excluded) ---")
+    tool_chars = non_tool_chars = 0
+    try:
+        rows = conn.execute("""SELECT m.tool_name, COUNT(*), SUM(LENGTH(m.content))
+                          FROM messages m JOIN sessions s ON m.session_id=s.id
+                          WHERE (s.started_at>=? OR s.last_activity_at>=?)
+                            AND m.active=1 AND m.tool_name IS NOT NULL AND m.tool_name!=''
+                          GROUP BY m.tool_name ORDER BY SUM(LENGTH(m.content)) DESC LIMIT 10""",
+                            (cutoff, cutoff)).fetchall()
+        tool_chars = sum((r[2] or 0) for r in rows)
+        for tn, n, sz in rows:
+            print(f"  {str(tn):24} n={n:>6} chars={sz or 0:>12,}")
+        row = conn.execute("""SELECT COALESCE(SUM(LENGTH(m.content)),0)
+                          FROM messages m JOIN sessions s ON m.session_id=s.id
+                          WHERE (s.started_at>=? OR s.last_activity_at>=?)
+                            AND m.active=1 AND (m.tool_name IS NULL OR m.tool_name='')""",
+                           (cutoff, cutoff)).fetchone()
+        non_tool_chars = row[0]
+        if (tool_chars + non_tool_chars) > 0:
+            share = 100 * tool_chars / (tool_chars + non_tool_chars)
+            print(f"  tool chars share of stored active content: {share:.0f}% "
+                  f"(tool {tool_chars:,} / non-tool {non_tool_chars:,}; stored ~= upper bound on sent)")
+    except sqlite3.OperationalError as e:
+        print(f"  messages table error: {e}")
+
+    try:
+        row = conn.execute("""SELECT COUNT(*), SUM(LENGTH(m.content))
+                         FROM messages m JOIN sessions s ON m.session_id=s.id
+                         WHERE (s.started_at>=? OR s.last_activity_at>=?) AND m.active=1
+                           AND m.tool_name IS NOT NULL AND m.tool_name!=''
+                           AND LENGTH(m.content) > 50000""", (cutoff, cutoff)).fetchone()
+        n, sz = row[0], row[1] or 0
+        print(f"  active results over 50k chars (tool_output.max_bytes default): {n} ({sz:,} chars)")
+    except sqlite3.OperationalError:
+        pass
+
+    try:
+        row = conn.execute("""SELECT COUNT(*), COALESCE(AVG(LENGTH(m.content)),0)
+                         FROM messages m JOIN sessions s ON m.session_id=s.id
+                         WHERE (s.started_at>=? OR s.last_activity_at>=?) AND m.active=1
+                           AND m.tool_name='skill_view'""", (cutoff, cutoff)).fetchone()
+        print(f"  skill_view loads (active): {row[0]}, avg chars {row[1]:,.0f}")
+    except sqlite3.OperationalError:
+        pass
+
+    conn.close()
+
+
+def pathlib_uri(db_path):
+    """Build a file: URI with the path properly encoded."""
+    p = os.path.abspath(db_path)
+    return "file:" + urllib.parse.quote(p)
+
+
+def audit_cron(ledger, jobs_path, cutoff):
+    if not os.path.exists(ledger):
+        print(f"\n[cron] ledger not found: {ledger}")
+        return
+    names = {}
+    if os.path.exists(jobs_path):
+        try:
+            d = json.load(open(jobs_path))
+            jobs = d["jobs"] if isinstance(d, dict) and "jobs" in d else (d if isinstance(d, list) else [])
+            for j in jobs:
+                if isinstance(j, dict):
+                    names[j.get("id") or j.get("job_id")] = j.get("name")
+            if not names:
+                print("  note: jobs.json parsed but contained no job names")
+        except Exception as e:
+            print(f"  jobs.json parse error: {e}")
+
+    cutoff_str = time.strftime("%Y-%m-%d %H:%M:%S", time.gmtime(cutoff))
+    byjob = collections.defaultdict(lambda: [0, 0, 0])  # tokens, fires, max
+    for line in open(ledger):
+        try:
+            r = json.loads(line)
+        except Exception:
+            continue
+        ts = (r.get("ts") or "").replace("T", " ")[:19]  # normalize ISO-T to space for string compare
+        if ts < cutoff_str:
+            continue
+        pt = r.get("prompt_tokens") or 0
+        e = byjob[r.get("job_id") or "(unknown job)"]
+        e[0] += pt; e[1] += 1; e[2] = max(e[2], pt)
+    print(f"\n=== cron ledger (fires since {cutoff_str} UTC; prompt_tokens semantics per fire: see SKILL.md) ===")
+    tot = 0
+    for jid, (tokens, fires, mx) in sorted(byjob.items(), key=lambda kv: -kv[1][0]):
+        tot += tokens
+        flag = " FLAG>2M-avg" if fires and tokens / fires > 2_000_000 else ""
+        print(f"  {str(jid)[:12]:12} {str(names.get(jid, jid if jid == '(unknown job)' else '?'))[:34]:34} fires={fires:>3} "
+              f"tokens={tokens:>13,} avg={tokens // max(fires, 1):>11,} max={mx:>11,}{flag}")
+    print(f"  TOTAL cron prompt tokens: {tot:,}")
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--days", type=int, default=30)
+    ap.add_argument("--db", default=os.path.join(HERMES, "state.db"))
+    ap.add_argument("--cron-audit", default=os.path.join(HERMES, "cron", "usage_audit.jsonl"))
+    ap.add_argument("--jobs", default=os.path.join(HERMES, "cron", "jobs.json"))
+    args = ap.parse_args()
+    cutoff = time.time() - args.days * 86400
+    print(f"# Input token audit — last {args.days} days — generated {time.strftime('%Y-%m-%d %H:%M %Z', time.localtime())}")
+    audit_sessions(args.db, cutoff)
+    audit_cron(args.cron_audit, args.jobs, cutoff)
+    print("\n# Interpretation levers: see SKILL.md (input-token-analysis)")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Two changes:

- **agent-ops/input-token-analysis** (new skill): audits aggregate input-token consumption from state.db (session_model_usage, sessions, messages) + the cron usage ledger. Deterministic read-only script (pure stdlib) + interpretation table mapping each finding to a config/prompt lever. Handles provider cache-convention differences (Anthropic-style cache_read reported in addition to input vs OpenAI-style subset), weighted per-call averages, active-only message filtering, cost-based ranking. Includes a mandatory pre-check discipline: verify config values live and mechanisms against config_defaults/docs before advising; unverifiable claims are labeled UNVERIFIED.

- **hermes-onboarding**: Step 18 maintenance crons 3 -> 4 — adds a 30-day input-token audit cron (agent mode, invokes the new skill, includes its prompt skeleton). Step 19 verification table gains the audit job + skill install check. Step 20 installs the skill the cron depends on.

Follows writing-for-agents principles: trigger-first description, checkable completion criteria on every step, no instance-specific values.