### PR TITLE
feat(skill-retrieval): add compaction opt-out

### DIFF
--- a/plugins/skill-retrieval/README.md
+++ b/plugins/skill-retrieval/README.md
@@ -24,11 +24,13 @@ Restart the Hermes session so the plugin's `register()` runs.
 | Setting | Default | Override |
 |---------|---------|----------|
 | Top-K results | `6` | `SKILL_RETRIEVAL_TOP_K` env var |
+| System prompt compaction | enabled | `SKILL_RETRIEVAL_COMPACT=0` disables compaction but keeps retrieval injection |
 | BM25 k1 | `1.5` | edit `scripts/bm25_retriever.py` |
 | BM25 b | `0.75` | edit `scripts/bm25_retriever.py` |
 
 ```bash
 export SKILL_RETRIEVAL_TOP_K=8
+export SKILL_RETRIEVAL_COMPACT=0  # retrieval-only mode; no prompt-builder monkey patch
 ```
 
 ## Uninstall

--- a/plugins/skill-retrieval/SKILL.md
+++ b/plugins/skill-retrieval/SKILL.md
@@ -102,11 +102,13 @@ pip install pyyaml
 | Setting | Default | How to set |
 |---------|---------|------------|
 | `TOP_K` | `6` | Env var `SKILL_RETRIEVAL_TOP_K` |
+| System prompt compaction | enabled | Set `SKILL_RETRIEVAL_COMPACT=0` to disable compaction while keeping BM25 retrieval injection |
 | BM25 `k1` | `1.5` | Constant in `scripts/bm25_retriever.py` |
 | BM25 `b` | `0.75` | Constant in `scripts/bm25_retriever.py` |
 
 ```bash
 export SKILL_RETRIEVAL_TOP_K=8
+export SKILL_RETRIEVAL_COMPACT=0
 ```
 
 ## Verify it's working

--- a/plugins/skill-retrieval/__init__.py
+++ b/plugins/skill-retrieval/__init__.py
@@ -15,6 +15,9 @@ better discovery than dumping every description into the system prompt.
 
 Configuration:
   TOP_K defaults to 6. Override with env var ``SKILL_RETRIEVAL_TOP_K``.
+  System prompt compaction is enabled by default. Set
+  ``SKILL_RETRIEVAL_COMPACT=0`` to keep retrieval injection while leaving the
+  original Hermes skills prompt untouched.
 """
 
 import logging
@@ -54,7 +57,21 @@ def _parse_top_k(raw: str | None, default: int = _DEFAULT_TOP_K) -> int:
     return value
 
 
+def _parse_bool_env(raw: str | None, *, default: bool = True) -> bool:
+    """Parse a permissive boolean env var without failing plugin startup."""
+    if raw is None or not str(raw).strip():
+        return default
+    value = str(raw).strip().lower()
+    if value in {"1", "true", "yes", "on"}:
+        return True
+    if value in {"0", "false", "no", "off"}:
+        return False
+    logger.warning("Invalid SKILL_RETRIEVAL_COMPACT=%r — using default %s", raw, default)
+    return default
+
+
 TOP_K = _parse_top_k(os.environ.get("SKILL_RETRIEVAL_TOP_K"))
+COMPACT_SYSTEM_PROMPT = _parse_bool_env(os.environ.get("SKILL_RETRIEVAL_COMPACT"))
 
 # Capability snapshots captured from compact_build (Hermes'
 # build_skills_system_prompt kwargs) so the retrieval hook can rebuild the
@@ -278,14 +295,21 @@ def _on_pre_llm_call(session_id: str, user_message: str, **kwargs) -> dict | Non
 
 
 def register(ctx):
-    """Register the pre_llm_call hook and compact the skills system prompt."""
+    """Register the pre_llm_call hook and optionally compact the skills system prompt."""
     # Phase 1: Compact system prompt (names-only). Failures are logged inside
     # _compact_skills_prompt — never abort registration of the retrieval hook.
-    try:
-        _compact_skills_prompt()
-    except Exception as e:
-        logger.warning("System prompt compaction failed: %s", e, exc_info=True)
+    if COMPACT_SYSTEM_PROMPT:
+        try:
+            _compact_skills_prompt()
+        except Exception as e:
+            logger.warning("System prompt compaction failed: %s", e, exc_info=True)
+    else:
+        logger.info("System prompt compaction disabled by SKILL_RETRIEVAL_COMPACT")
 
     # Phase 2: Per-turn retrieval
     ctx.register_hook("pre_llm_call", _on_pre_llm_call)
-    logger.info("Skill retrieval plugin registered (top_k=%d, compact=true)", TOP_K)
+    logger.info(
+        "Skill retrieval plugin registered (top_k=%d, compact=%s)",
+        TOP_K,
+        str(COMPACT_SYSTEM_PROMPT).lower(),
+    )

--- a/plugins/skill-retrieval/tests/test_bm25_retriever.py
+++ b/plugins/skill-retrieval/tests/test_bm25_retriever.py
@@ -392,23 +392,25 @@ def test_get_index_cache_is_scoped_by_hermes_home(monkeypatch, tmp_path):
         str((tmp_path / "profile-b").resolve(strict=False)),
     }
 
-# ─── plugin TOP_K parsing ────────────────────────────────────────────────────
-
-def test_parse_top_k_defaults_and_rejects_invalid():
-    import importlib
+def _load_plugin_module(module_name="skill_retrieval_plugin"):
+    import importlib.util
     import sys
     from pathlib import Path
 
     plugin_dir = Path(__file__).resolve().parent.parent
     sys.path.insert(0, str(plugin_dir))
-    # Import the package __init__ as a module under a unique name so we can
-    # call the helper without requiring a Hermes runtime.
-    import importlib.util
     spec = importlib.util.spec_from_file_location(
-        "skill_retrieval_plugin", plugin_dir / "__init__.py"
+        module_name, plugin_dir / "__init__.py"
     )
     mod = importlib.util.module_from_spec(spec)
     spec.loader.exec_module(mod)
+    return mod
+
+
+# ─── plugin env parsing ───────────────────────────────────────────────────────
+
+def test_parse_top_k_defaults_and_rejects_invalid():
+    mod = _load_plugin_module("skill_retrieval_top_k_test")
 
     assert mod._parse_top_k(None) == 6
     assert mod._parse_top_k("") == 6
@@ -416,3 +418,40 @@ def test_parse_top_k_defaults_and_rejects_invalid():
     assert mod._parse_top_k("nope") == 6
     assert mod._parse_top_k("0") == 6
     assert mod._parse_top_k("-3") == 6
+
+
+def test_parse_bool_env_accepts_compaction_switch_values():
+    mod = _load_plugin_module("skill_retrieval_bool_env_test")
+
+    assert mod._parse_bool_env(None) is True
+    assert mod._parse_bool_env("") is True
+    assert mod._parse_bool_env("1") is True
+    assert mod._parse_bool_env("true") is True
+    assert mod._parse_bool_env("yes") is True
+    assert mod._parse_bool_env("on") is True
+    assert mod._parse_bool_env("0") is False
+    assert mod._parse_bool_env("false") is False
+    assert mod._parse_bool_env("no") is False
+    assert mod._parse_bool_env("off") is False
+    assert mod._parse_bool_env("nonsense") is True
+
+
+def test_register_can_disable_prompt_compaction(monkeypatch):
+    mod = _load_plugin_module("skill_retrieval_register_compact_test")
+    called = []
+
+    class Ctx:
+        def __init__(self):
+            self.hooks = []
+
+        def register_hook(self, name, func):
+            self.hooks.append((name, func))
+
+    monkeypatch.setattr(mod, "COMPACT_SYSTEM_PROMPT", False)
+    monkeypatch.setattr(mod, "_compact_skills_prompt", lambda: called.append(True))
+
+    ctx = Ctx()
+    mod.register(ctx)
+
+    assert called == []
+    assert ctx.hooks == [("pre_llm_call", mod._on_pre_llm_call)]


### PR DESCRIPTION
## Summary
- Add `SKILL_RETRIEVAL_COMPACT=0` to disable system-prompt compaction while keeping retrieval injection
- Document retrieval-only mode in README and SKILL.md
- Add env parsing and registration regression tests

## Verification
- `python -m pytest -q plugins/skill-retrieval/tests`
- `python -m pytest -q tests/test_routing_fixtures.py plugins/skill-retrieval/tests`